### PR TITLE
Fix documentation file reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ header configuration specific to the given rule.
 Example:
 
 ```php
-// See the `config/application.config.php` for a complete commented example
+// See `config/module.config.php` for a complete commented example
 'zf-http-cache' => [
     /* ... */
     'controllers' => [


### PR DESCRIPTION
Hi,

I noticed that there was a typo in the code example pointing the user to the application config instead of the module config.

Thanks,
Rob